### PR TITLE
README: added topics under each week

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
 #  Embedded Systems Study Group
 
-* [Week 1](week1/week1.md)
-* [Week 2](week2/week2.md)
-* [Week 3](week3/week3.md)
-* [Week 4](week4/week4.md)
-* [Week 5](week5/week5.md)
-* [Week 6](week6/week6.md)
-
+* [Week 1:](week1/week1.md) Basic of Electronics
+* [Week 2:](week2/week2.md) Basics of Embedded Programming
+* [Week 3:](week3/week3.md) 
+    - Fundamental Concepts: PWM, L298N Motor Driver, Proteus Simulation
+    - ESP32 Block Diagram, and Registers in MCU
+    - Memory Allocation in C
+    - Types of Memory in Embedded Systems: RAM, ROM, Hybrid
+    - Bootloader
+* [Week 4:](week4/week4.md)
+    - Dynamic memory
+    - Storage Classes in C
+    - Byte ordering
+* [Week 5:](week5/week5.md)
+    - Basic of ADC and DAC, ESP32 ADC and DAC
+    - Bit manipulations
+    - GPIO
+* [Week 6:](week6/week6.md) FreeRTOS
 ## Conducted by
 - [Sravan Chittupalli](https://github.com/SravanChittupalli)
 - [Vedant Paranjape](https://github.com/VedantParanjape)


### PR DESCRIPTION
If a first time visitor has to find his way around topics it's difficult to do so using the previous index where there were only week numbers. By adding the main topic(s) covered under each week it makes these notes much easier to use.